### PR TITLE
InstrumentService to decouple Strategy and MarketData

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,8 @@
 name: Publish Docker
-on: [push]
+on:
+  push:
+    branches:
+    - master
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 *.json
 .cache/
 .aws
+.env
 thirdparty/googletest/
 tmp
 CMakeLists.txt.user

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ build/
 .env
 thirdparty/googletest/
 tmp
+wip
 CMakeLists.txt.user
 CMakeCache.txt
 CMakeFiles

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,6 +30,8 @@ add_library(trading_funcs SHARED
         HeartBeat.cpp
 		Signal.cpp
 		CallbackTimer.cpp
+		Functional.cpp
+		InstrumentService.cpp
 
 		signal/MovingAverageCrossOver.cpp
 

--- a/src/Context.h
+++ b/src/Context.h
@@ -52,6 +52,7 @@ public:
     /// load symbol from library file, download instrument from InstrumentApi, and call strategy::init
     void initStrategy();
 
+    /// accessor functions
     const std::shared_ptr<TMarketData>& marketData() const { return _marketData; }
     const std::shared_ptr<TOrderApi>& orderApi() const { return _orderManager; }
     const std::shared_ptr<api::ApiConfiguration>& apiConfig() const { return _apiConfig; }
@@ -102,8 +103,6 @@ Context<TMarketData, TOrderApi>::loadFactoryMethod() {
 
 template<typename TMarketData, typename TOrderApi>
 Context<TMarketData, TOrderApi>::Context(const std::shared_ptr<Config>& config_) {
-
-
 
     _config = config_;
     setupLogger();

--- a/src/Functional.cpp
+++ b/src/Functional.cpp
@@ -1,0 +1,20 @@
+//
+// Created by rory on 11/10/2021.
+//
+
+#include "Functional.h"
+
+std::shared_ptr<model::Instrument>
+func::get_instrument(const std::shared_ptr<api::InstrumentApi> &_instrumentApi, const std::string &symbol_) {
+    std::shared_ptr<model::Instrument> inst;
+    auto instTask = _instrumentApi->instrument_get(symbol_, SEVENNULL).then(
+            [&inst](pplx::task<std::vector<std::shared_ptr<model::Instrument>>> instr_) {
+                try {
+                    inst = instr_.get()[0];
+                } catch (std::exception &ex) {
+                    LOGERROR("Http exception raised " << LOG_VAR(ex.what()));
+                    inst = nullptr;
+                }
+            });
+    return inst;
+}

--- a/src/Functional.h
+++ b/src/Functional.h
@@ -1,0 +1,25 @@
+//
+// Created by rory on 11/10/2021.
+//
+
+#ifndef TRADINGO_FUNCTIONAL_H
+#define TRADINGO_FUNCTIONAL_H
+
+#include "api/InstrumentApi.h"
+#include "model/Instrument.h"
+
+#include "Utils.h"
+using namespace io::swagger::client;
+
+#define SEVENNULL boost::none,boost::none,boost::none,boost::none,boost::none,boost::none,boost::none
+
+namespace func {
+
+
+std::shared_ptr<model::Instrument>
+get_instrument(const std::shared_ptr<api::InstrumentApi>& _instrumentApi, const std::string& symbol_);
+
+} // func
+
+
+#endif //TRADINGO_FUNCTIONAL_H

--- a/src/InstrumentService.cpp
+++ b/src/InstrumentService.cpp
@@ -1,0 +1,27 @@
+//
+// Created by rory on 12/10/2021.
+//
+
+#include "Functional.h"
+#include <api/InstrumentApi.h>
+#include <model/Instrument.h>
+
+#include <utility>
+
+#include "InstrumentService.h"
+
+
+InstrumentService::InstrumentService(std::shared_ptr<api::ApiClient> apiClient_, std::shared_ptr<Config> config_)
+:   _instrumentApi(std::make_shared<api::InstrumentApi>(apiClient_))
+,   _config(std::move(config_)) {
+
+    _instruments[_config->get("symbol")] = func::get_instrument(_instrumentApi, config_->get("symbol"));
+
+}
+
+const std::shared_ptr<model::Instrument>& InstrumentService::get(const std::string& symbol_, bool reload) {
+    if (not reload && _instruments.find(symbol_) != _instruments.end())
+        return _instruments[symbol_];
+    _instruments[symbol_] = func::get_instrument(_instrumentApi, symbol_);
+    return _instruments[symbol_];
+}

--- a/src/InstrumentService.cpp
+++ b/src/InstrumentService.cpp
@@ -11,11 +11,12 @@
 #include "InstrumentService.h"
 
 
-InstrumentService::InstrumentService(std::shared_ptr<api::ApiClient> apiClient_, std::shared_ptr<Config> config_)
+InstrumentService::InstrumentService(const std::shared_ptr<api::ApiClient>& apiClient_, std::shared_ptr<Config> config_)
 :   _instrumentApi(std::make_shared<api::InstrumentApi>(apiClient_))
+,   _instruments()
 ,   _config(std::move(config_)) {
 
-    _instruments[_config->get("symbol")] = func::get_instrument(_instrumentApi, config_->get("symbol"));
+    _instruments[_config->get("symbol")] = func::get_instrument(_instrumentApi, _config->get("symbol"));
 
 }
 
@@ -24,4 +25,9 @@ const std::shared_ptr<model::Instrument>& InstrumentService::get(const std::stri
         return _instruments[symbol_];
     _instruments[symbol_] = func::get_instrument(_instrumentApi, symbol_);
     return _instruments[symbol_];
+}
+
+void InstrumentService::add(std::shared_ptr<model::Instrument> instr_) {
+    _instruments[instr_->getSymbol()] = std::move(instr_);
+
 }

--- a/src/InstrumentService.h
+++ b/src/InstrumentService.h
@@ -15,10 +15,11 @@ class InstrumentService {
     std::shared_ptr<Config> _config;
     std::unordered_map<std::string, std::shared_ptr<api::Instrument>> _instruments;
 public:
-    explicit InstrumentService(std::shared_ptr<api::ApiClient> apiClient_, std::shared_ptr<Config> config_);
+    explicit InstrumentService(const std::shared_ptr<api::ApiClient>& apiClient_, std::shared_ptr<Config> config_);
 
 
     const std::shared_ptr<model::Instrument>& get(const std::string& symbol_, bool reload_=false);
+    void add(const std::shared_ptr<model::Instrument> inst_);
 };
 
 #endif //TRADINGO_INSTRUMENTSERVICE_H

--- a/src/InstrumentService.h
+++ b/src/InstrumentService.h
@@ -1,0 +1,24 @@
+//
+// Created by rory on 12/10/2021.
+//
+
+#ifndef TRADINGO_INSTRUMENTSERVICE_H
+#define TRADINGO_INSTRUMENTSERVICE_H
+#include <unordered_map>
+#include <api/InstrumentApi.h>
+#include <model/Instrument.h>
+#include "Config.h"
+
+class InstrumentService {
+
+    std::shared_ptr<api::InstrumentApi> _instrumentApi;
+    std::shared_ptr<Config> _config;
+    std::unordered_map<std::string, std::shared_ptr<api::Instrument>> _instruments;
+public:
+    explicit InstrumentService(std::shared_ptr<api::ApiClient> apiClient_, std::shared_ptr<Config> config_);
+
+
+    const std::shared_ptr<model::Instrument>& get(const std::string& symbol_, bool reload_=false);
+};
+
+#endif //TRADINGO_INSTRUMENTSERVICE_H

--- a/src/MarketData.cpp
+++ b/src/MarketData.cpp
@@ -9,7 +9,8 @@
 #include <model/Order.h>
 
 #include <auth_helpers.h>
-
+#include "Functional.h"
+#include "InstrumentService.h"
 
 
 std::string MarketData::getConnectionUri() {
@@ -37,8 +38,8 @@ MarketData::~MarketData() {
 
 
 
-MarketData::MarketData(const std::shared_ptr<Config>& config_)
-:   MarketDataInterface(config_)
+MarketData::MarketData(const std::shared_ptr<Config>& config_, std::shared_ptr<InstrumentService> instrumentSvc_)
+:   MarketDataInterface(config_, instrumentSvc_)
 ,   _connectionString(config_->get("connectionString"))
 ,   _apiKey(config_->get("apiKey", "NO_AUTH"))
 ,   _apiSecret(config_->get("apiSecret", "NO_AUTH"))
@@ -58,18 +59,6 @@ MarketData::MarketData(const std::shared_ptr<Config>& config_)
 void MarketData::init() {
 
     _heartBeat = std::make_shared<HeartBeat>(_wsClient);
-
-    // get instrument
-#define SEVENNULL boost::none,boost::none,boost::none,boost::none,boost::none,boost::none,boost::none
-    auto instTask = _instrumentApi->instrument_get(_symbol, SEVENNULL).then(
-            [this](pplx::task<std::vector<std::shared_ptr<model::Instrument>>> instr_) {
-                try {
-                    LOGINFO("Instrument: " << instr_.get()[0]->toJson().serialize());
-                    _instrument = instr_.get()[0];
-                } catch (std::exception &ex) {
-                    LOGINFO("Http exception raised " << LOG_VAR(ex.what()));
-                }
-            });
 
     // initialise callback
     _wsClient->set_message_handler(
@@ -205,10 +194,6 @@ void MarketData::reconnect() {
     subscribe();
 }
 
-void MarketDataInterface::setInstrumentApi(const std::shared_ptr<api::InstrumentApi> &instrumentApi) {
-    _instrumentApi = instrumentApi;
-}
-
 template<typename T>
 void MarketDataInterface::update(const std::vector<std::shared_ptr<T>> &data_) {
     for (const auto& row : data_) {
@@ -335,9 +320,11 @@ const std::shared_ptr<model::Instrument>& MarketDataInterface::instrument() cons
 }
 
 
-MarketDataInterface::MarketDataInterface(const std::shared_ptr<Config>& config_)
-:   _instrumentApi(nullptr)
+MarketDataInterface::MarketDataInterface(const std::shared_ptr<Config>& config_,
+                                         const std::shared_ptr<InstrumentService>& instSvc_)
+:    _instSvc(instSvc_)
 ,   _symbol(config_->get("symbol"))
+,   _instrument(_instSvc->get(_symbol))
 ,   _callback([]() {}){
 }
 

--- a/src/MarketData.cpp
+++ b/src/MarketData.cpp
@@ -9,6 +9,8 @@
 #include <model/Order.h>
 
 #include <auth_helpers.h>
+
+#include <utility>
 #include "Functional.h"
 #include "InstrumentService.h"
 
@@ -321,11 +323,13 @@ const std::shared_ptr<model::Instrument>& MarketDataInterface::instrument() cons
 
 
 MarketDataInterface::MarketDataInterface(const std::shared_ptr<Config>& config_,
-                                         const std::shared_ptr<InstrumentService>& instSvc_)
-:    _instSvc(instSvc_)
+                                         std::shared_ptr<InstrumentService>  instSvc_)
+:   _instSvc(std::move(instSvc_))
 ,   _symbol(config_->get("symbol"))
-,   _instrument(_instSvc->get(_symbol))
-,   _callback([]() {}){
+,   _instrument()
+,   _callback([]() {}) {
+
+    _instrument = _instSvc->get(_symbol);
 }
 
 void MarketDataInterface::setCallback(const std::function<void()> &callback) {

--- a/src/MarketData.h
+++ b/src/MarketData.h
@@ -26,6 +26,7 @@
 #include "HeartBeat.h"
 #include "Allocation.h"
 #include "api/InstrumentApi.h"
+#include "InstrumentService.h"
 //#include "Signal.h"
 
 
@@ -142,16 +143,16 @@ public:
 
     std::function<void()> _callback;
 
-        void setCallback(const std::function<void()> &callback);
+    void setCallback(const std::function<void()> &callback);
 
 private:
     std::priority_queue<std::shared_ptr<Event>, std::vector<std::shared_ptr<Event>>, QueueArrange> _eventBuffer;
     //std::unordered_map<std::string, std::shared_ptr<Signal>> _timed_signals;
+
 private:
     void updateSignals(const std::shared_ptr<Event>& event_);
 public:
     void initSignals(const std::string& cfg_);
-    void setInstrumentApi(const std::shared_ptr<api::InstrumentApi> &instrumentApi);
 
 protected:
     std::mutex _mutex;
@@ -170,7 +171,7 @@ protected:
     std::unordered_map<std::string, std::shared_ptr<model::Order>> _orders;
     std::shared_ptr<model::Quote> _quote;
     std::shared_ptr<model::Instrument> _instrument;
-    std::shared_ptr<api::InstrumentApi> _instrumentApi;
+    std::shared_ptr<InstrumentService> _instSvc;
 
     void handleQuotes(const std::vector<std::shared_ptr<model::Quote>>& quotes_, const std::string& action_);
     void handleTrades(std::vector<std::shared_ptr<model::Trade>>& trades_, const std::string& action_);
@@ -196,7 +197,7 @@ protected:
 
 public:
     ~MarketDataInterface() = default;
-    explicit MarketDataInterface(const std::shared_ptr<Config>& config_);
+    MarketDataInterface(const std::shared_ptr<Config>& config_, const std::shared_ptr<InstrumentService>& insSvc_);
     MarketDataInterface();
     std::shared_ptr<Event> read();
     const std::unordered_map<std::string, OrderPtr>& getOrders() const;
@@ -233,11 +234,12 @@ public:
     void subscribe();
     void reconnect();
 
-    explicit MarketData(const std::shared_ptr<Config>& config_);
+    MarketData(const std::shared_ptr<Config>& config_, std::shared_ptr<InstrumentService>);
 
     ~MarketData();
 
     void init();
+
 };
 
 #endif //TRADING_BOT_MARKETDATA_H

--- a/src/MarketData.h
+++ b/src/MarketData.h
@@ -197,7 +197,7 @@ protected:
 
 public:
     ~MarketDataInterface() = default;
-    MarketDataInterface(const std::shared_ptr<Config>& config_, const std::shared_ptr<InstrumentService>& insSvc_);
+    MarketDataInterface(const std::shared_ptr<Config>& config_, std::shared_ptr<InstrumentService>  insSvc_);
     MarketDataInterface();
     std::shared_ptr<Event> read();
     const std::unordered_map<std::string, OrderPtr>& getOrders() const;

--- a/test/benchmark/data_parsing.cpp
+++ b/test/benchmark/data_parsing.cpp
@@ -24,7 +24,7 @@ static void BM_read_quotes_json(benchmark::State& state) {
     ) config->set(kvp.first, kvp.second);
 
     std::ifstream quoteFile;
-    auto marketdata = std::make_shared<TestMarketData>(config);
+    auto marketdata = std::make_shared<TestMarketData>(config, nullptr);
     auto signal = std::make_shared<MovingAverageCrossOver>(1000, 8000);
     signal->init(config, marketdata);
     marketdata->setCallback([&](){ signal->update(); });

--- a/test/fwk/TestEnv.cpp
+++ b/test/fwk/TestEnv.cpp
@@ -196,6 +196,7 @@ void TestEnv::init() {
     if (_config->get("logLevel", "").empty())
         _config->set("logLevel", "debug");
     _config->set("cloidSeed", "0");
+    auto instSvc = std::shared_ptr<InstrumentService>(nullptr);
     _context = std::make_shared<Context<TestMarketData, OrderApi>>(_config);
     _context->init();
     _context->initStrategy();

--- a/test/fwk/TestEnv.h
+++ b/test/fwk/TestEnv.h
@@ -47,6 +47,12 @@ struct Dispatch {
         {"libraryLocation", LIBRARY_LOCATION"/libtest_trading_strategies.so" }, \
         {"storage", "./"},   \
         {"tickStorage", "./"}
+
+#define INSERT_DEFAULT_ARGS(config_) \
+    std::initializer_list<std::pair<std::string, std::string>> defaults = { DEFAULT_ARGS }; \
+    for (auto pair : defaults) \
+        (config_)->set(pair.first, pair.second);
+
 class TestEnv
 {
     using OrderApi = TestOrdersApi;

--- a/test/fwk/TestMarketData.cpp
+++ b/test/fwk/TestMarketData.cpp
@@ -53,8 +53,8 @@ void TestMarketData::operator<<(const std::string &marketDataString) {
 
 }
 
-TestMarketData::TestMarketData(const std::shared_ptr<Config>& ptr)
-: MarketDataInterface(ptr)
+TestMarketData::TestMarketData(const std::shared_ptr<Config>& ptr, std::shared_ptr<InstrumentService> instSvc_)
+: MarketDataInterface(ptr, instSvc_)
 , _config(ptr)
 , _time(utility::datetime::utc_now()){
 

--- a/test/fwk/TestMarketData.cpp
+++ b/test/fwk/TestMarketData.cpp
@@ -53,7 +53,7 @@ void TestMarketData::operator<<(const std::string &marketDataString) {
 
 }
 
-TestMarketData::TestMarketData(const std::shared_ptr<Config>& ptr, std::shared_ptr<InstrumentService> instSvc_)
+TestMarketData::TestMarketData(const std::shared_ptr<Config>& ptr, const std::shared_ptr<InstrumentService>& instSvc_)
 : MarketDataInterface(ptr, instSvc_)
 , _config(ptr)
 , _time(utility::datetime::utc_now()){

--- a/test/fwk/TestMarketData.h
+++ b/test/fwk/TestMarketData.h
@@ -16,7 +16,7 @@ class TestMarketData : public MarketDataInterface {
     utility::datetime _time;
 
 public:
-    explicit TestMarketData(const std::shared_ptr<Config>& ptr);
+    TestMarketData(const std::shared_ptr<Config>& ptr, const std::shared_ptr<InstrumentService> instSvc_);
     TestMarketData();
     void init();
     void subscribe() {}

--- a/test/fwk/TestMarketData.h
+++ b/test/fwk/TestMarketData.h
@@ -16,7 +16,7 @@ class TestMarketData : public MarketDataInterface {
     utility::datetime _time;
 
 public:
-    TestMarketData(const std::shared_ptr<Config>& ptr, const std::shared_ptr<InstrumentService> instSvc_);
+    TestMarketData(const std::shared_ptr<Config>& ptr, const std::shared_ptr<InstrumentService>& instSvc_);
     TestMarketData();
     void init();
     void subscribe() {}

--- a/test/test_api_OrderApi.cpp
+++ b/test/test_api_OrderApi.cpp
@@ -10,7 +10,13 @@
 // CppRestSwaggerClient
 #include "api/OrderApi.h"
 
+#include "fwk/TestEnv.h"
+
 using namespace io::swagger::client;
+
+auto ORDER_PRICE = 47000;
+auto ORDER_QTY = 100;
+auto SIDE = "Buy";
 
 struct OrderManager {
     std::shared_ptr<api::OrderApi> orderApi;
@@ -48,15 +54,20 @@ struct OrderManager {
 };
 
 TEST(TestStrategyInterface, smoke_test) {
-
-
-    auto config = std::shared_ptr<Config>();
+    auto config = std::make_shared<Config>();
     config->set("apiKey", "-rqipjFxM43WSRKdC8keq83K");
     config->set("apiSecret", "uaCYIiwpwpXNKuVGCBPWE3ThzvyhOzKs6F9mWFzc9LueG3yd");
     config->set("symbol", "XBTUSD");
     config->set("baseUrl", "https://testnet.bitmex.com/api/v1/");
     config->set("connectionString", "wss://testnet.bitmex.com");
+    INSERT_DEFAULT_ARGS(config);
     auto context = std::make_shared<Context<TestMarketData, api::OrderApi>>(config);
+    context->initStrategy();
+    context->strategy()->allocations()->addAllocation(ORDER_PRICE, ORDER_QTY);
+    context->strategy()->allocations()->addAllocation(ORDER_PRICE, ORDER_QTY);
+    context->strategy()->placeAllocations();
+    std::this_thread::sleep_for(std::chrono::seconds(10));
+    context->strategy()->allocations()->addAllocation(ORDER_PRICE, 2*ORDER_QTY);
 }
 
 TEST(OrderApi, DISABLED_order_newBulk) {

--- a/test/test_api_OrderApi.cpp
+++ b/test/test_api_OrderApi.cpp
@@ -4,6 +4,8 @@
 // src
 #include "Config.h"
 #include "MarketData.h"
+#include "Context.h"
+#include "fwk/TestMarketData.h"
 
 // CppRestSwaggerClient
 #include "api/OrderApi.h"
@@ -44,6 +46,18 @@ struct OrderManager {
     }
 
 };
+
+TEST(TestStrategyInterface, smoke_test) {
+
+
+    auto config = std::shared_ptr<Config>();
+    config->set("apiKey", "-rqipjFxM43WSRKdC8keq83K");
+    config->set("apiSecret", "uaCYIiwpwpXNKuVGCBPWE3ThzvyhOzKs6F9mWFzc9LueG3yd");
+    config->set("symbol", "XBTUSD");
+    config->set("baseUrl", "https://testnet.bitmex.com/api/v1/");
+    config->set("connectionString", "wss://testnet.bitmex.com");
+    auto context = std::make_shared<Context<TestMarketData, api::OrderApi>>(config);
+}
 
 TEST(OrderApi, DISABLED_order_newBulk) {
 
@@ -95,8 +109,5 @@ TEST(OrderApi, order_newBulk_throws_ApiException) {
     } catch (web::http::http_exception ex_) {
         LOGINFO("Httpexception!");
     }
-
-
-
     LOGINFO(LOG_VAR(res));
 }


### PR DESCRIPTION
Currently Strategy gets its instrument from the MarketData class.

In TestMarketData, instrument details are taken from config and an instrument is created as a member.

This does not work when we want to run a OrderApi during replayed market events.

To remedy, make instrument service owned by context.

`InstrumentService::add` method to add instrument for test, before anything is initialised.

This all started from requiring integration tests for Strategy order interface.

Also trying to add documentation where lacking